### PR TITLE
Non-destructive batch conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gdi-conversion
 
-gdi-conversion is a small Node.js program to convert Dreamcast Game Images (cue and bin files) to GDI Images in order to run on GDEmu.
+gdi-conversion is a small Node.js program to convert Dreamcast Game Images (cue and bin files) to GDI Images in order to run on GDEmu or further compression to CHD (as CHD files fails to run if compressed directly from bin/cue files).
 
 # Requirements
 
-gdi-conversion tool has been developed on Linux with node 16.2.0 and npm 7.14. Three executables files have been built for Linux, Macos and Windows.
+gdi-conversion tool has been developed on Linux with node 18.16.1 and npm 9.7.2. Three executables files have been built for Linux, Macos and Windows.
 
 # How to use it
 
@@ -42,6 +42,6 @@ gdi-conversion-linux -c ./MyUser/
 to convert recursively all .cue files in MyUser folder on linux
 
 ```
-gdi-conversion-win.exe -n ./Download/Game/disc.gdi
+gdi-conversion-win.exe -n ./Download/Game/[insert_your_disc_name].gdi
 ```
- to convert only Game/disc.gdi file on window
+ to convert only Game/[insert_your_disc_name].gdi file on windows

--- a/src/convert.js
+++ b/src/convert.js
@@ -9,6 +9,7 @@ const TRACK_TYPE_AUDIO = 'AUDIO';
 const BLOCK_SIZE = 2352;
 const OUTPUT_FOLDER = 'output';
 
+
 const parseFile = (absPath) => {
 	try {
 		return parser.parse(absPath);
@@ -60,8 +61,9 @@ const padTrackNumber = (currentTrack) => {
 	return currentTrack;
 };
 
-const createSummaryFile = (workingDirectory, gdiOutput) => {
-	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/disc.gdi`;
+const createSummaryFile = (workingDirectory, gdiOutput, absPath) => {
+  const filename = path.basename(absPath,'.cue');
+	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename}.gdi`;
 	fs.writeFile(outputGdiFilePath, gdiOutput, () => void 0);
 };
 
@@ -69,7 +71,7 @@ module.exports = function(absPath) {
 	const workingDirectory = path.dirname(absPath);
 
 	let currentSector = 0;
-	fsExtra.emptyDirSync(`${workingDirectory}/${OUTPUT_FOLDER}`);
+	//fsExtra.emptyDirSync(`${workingDirectory}/${OUTPUT_FOLDER}`);
 
 	const cueSheet = parseFile(absPath);
 	if (!cueSheet) {
@@ -84,7 +86,7 @@ module.exports = function(absPath) {
 		const inputTrackFilePath = `${workingDirectory}/${file.name}`;
 		const canPerformFullCopy = currentTrack.indexes.length == 1;
 		
-		const outputTrackFileName = `track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}`
+		const outputTrackFileName = `'${file.name.substring(0,file.name.indexOf("."))} track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}'`
 		
 		const outputTrackFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${outputTrackFileName}`;
 		const {size: inputTrackFileSize} = fs.statSync(inputTrackFilePath);
@@ -110,7 +112,7 @@ module.exports = function(absPath) {
 		}
 
 		if (index === files.length - 1) {
-			createSummaryFile(workingDirectory, gdiOutput);
+			createSummaryFile(workingDirectory, gdiOutput, absPath);
 			extractName(`${workingDirectory}/${OUTPUT_FOLDER}/`);
 		}
 	});

--- a/src/convert.js
+++ b/src/convert.js
@@ -86,7 +86,7 @@ module.exports = function(absPath) {
 		const inputTrackFilePath = `${workingDirectory}/${file.name}`;
 		const canPerformFullCopy = currentTrack.indexes.length == 1;
 		
-		const outputTrackFileName = `'${file.name.substring(0,file.name.indexOf("."))} track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}'`
+		const outputTrackFileName = `${file.name.substring(0,file.name.indexOf("."))} track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}`
 		
 		const outputTrackFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${outputTrackFileName}`;
 		const {size: inputTrackFileSize} = fs.statSync(inputTrackFilePath);

--- a/src/convert.js
+++ b/src/convert.js
@@ -74,7 +74,7 @@ const padTrackNumber = (currentTrack) => {
 
 const createSummaryFile = (workingDirectory, gdiOutput, absPath) => {
   const filename = path.basename(absPath,'.cue');
-	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'').replace(/([^.A-z])/g, '_')}.gdi`;
+	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'').replace(/([^.^\d^\w])/g, '_')}.gdi`;
 	fs.writeFile(outputGdiFilePath, gdiOutput, () => void 0);
 };
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -61,7 +61,7 @@ const padTrackNumber = (currentTrack) => {
 	return currentTrack;
 };
 
-// this Regex surely look rather arcane, though it was the more precise, 
+// this new function surely look rather arcane, though it was the more precise, 
 // fool-proof way to rename .gdi files by striping out any extra text 
 // inside ()[]{} (and these special characters themselves, along with others),
 // also trimming any extra spaces and replacing special chars
@@ -72,9 +72,16 @@ const padTrackNumber = (currentTrack) => {
 // functions or background shells, thus breaking the strings and
 // failing the compression operation
 
+const gdiFilenameParser = (filename) => {
+  const hasDisc = filename.match(/disc\s\d/gi);
+  const disc = hasDisc === null ? "" : hasDisc.toString();
+  const gdiname = `${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'')} ${disc}`;
+  return `${gdiname.replace(/([^.^\d^\w])/g, '_')}.gdi`;
+};
+
 const createSummaryFile = (workingDirectory, gdiOutput, absPath) => {
   const filename = path.basename(absPath,'.cue');
-	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'').replace(/([^.^\d^\w])/g, '_')}.gdi`;
+ 	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${gdiFilenameParser(filename)}`;
 	fs.writeFile(outputGdiFilePath, gdiOutput, () => void 0);
 };
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -76,7 +76,7 @@ const gdiFilenameParser = (filename) => {
   const hasDisc = filename.match(/disc\s\d/gi);
   const disc = hasDisc === null ? "" : hasDisc.toString();
   const gdiname = `${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'')} ${disc}`;
-  return `${gdiname.replace(/([^.^\d^\w])/g, '_')}.gdi`;
+  return `${gdiname.trim().replace(/([^.^\d^\w])/g, '_')}.gdi`;
 };
 
 const createSummaryFile = (workingDirectory, gdiOutput, absPath) => {

--- a/src/convert.js
+++ b/src/convert.js
@@ -61,9 +61,20 @@ const padTrackNumber = (currentTrack) => {
 	return currentTrack;
 };
 
+// this Regex surely look rather arcane, though it was the more precise, 
+// fool-proof way to rename .gdi files by striping out any extra text 
+// inside ()[]{} (and these special characters themselves, along with others),
+// also trimming any extra spaces and replacing special chars
+// and spaces between words with _ that might restrain chdman
+// or any chain/batch operations to do its job.
+// This might be especially true when running scripts on PowerShell
+// or UNIX shell that might interpret these encapsulations as
+// functions or background shells, thus breaking the strings and
+// failing the compression operation
+
 const createSummaryFile = (workingDirectory, gdiOutput, absPath) => {
   const filename = path.basename(absPath,'.cue');
-	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename}.gdi`;
+	const outputGdiFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${filename.replace(/[\s]?[\[\(\{]([\s]?[\w]+.?[\w]+[\s]?)+?[\]\)\}][\s]?/g,'').replace(/([^.A-z])/g, '_')}.gdi`;
 	fs.writeFile(outputGdiFilePath, gdiOutput, () => void 0);
 };
 
@@ -86,7 +97,7 @@ module.exports = function(absPath) {
 		const inputTrackFilePath = `${workingDirectory}/${file.name}`;
 		const canPerformFullCopy = currentTrack.indexes.length == 1;
 		
-		const outputTrackFileName = `${file.name.substring(0,file.name.indexOf("."))} track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}`
+		const outputTrackFileName = `${file.name.substring(0,file.name.indexOf("."))} track${padTrackNumber(currentTrack.number)}.${currentTrack.type === TRACK_TYPE_AUDIO ? "raw" : "bin"}`;
 		
 		const outputTrackFilePath = `${workingDirectory}/${OUTPUT_FOLDER}/${outputTrackFileName}`;
 		const {size: inputTrackFileSize} = fs.statSync(inputTrackFilePath);


### PR DESCRIPTION
Hi, I was just playing around with gdi-conversion since I had the bad luck of downloading a whole archive of bin/cue files instead of going into new gdi redumps. This was the only tool that actually worked, still I found that recursive conversion didn't work as intented

- Using only gdi-conversion -c [folder] it raises a EPERM error for the file handling process
- Pointing it to a single cue file does work, however the app overwrites the output folder for every run making batch conversion impossible

Just wanted to share this mod as a pull request, feel free to reject or merge it if desirable. Only made a couple changes to convert.js:

- Changed the script in order to comment `fsExtra.emptyDirSync` so the output folder is not overwritten for each file, allowing batch conversion (can be changed into making separate folders named after the cue basename instead, but it would require some extra work on getting OUTPUT_FOLDER name from absPath);
- Modified both createSummaryFile and outputTrackFileName to set the new files with the names from the original cue/bin files so we have automatic renaming